### PR TITLE
add --help

### DIFF
--- a/bin/ac.js
+++ b/bin/ac.js
@@ -5,6 +5,7 @@ var arguments = require("minimist")(process.argv.slice(2));
 
 var functionType = arguments["_"][0];
 var number = arguments["_"][1];
+var help = arguments["help"]
 
 var ac = module.exports = {};
 
@@ -25,3 +26,16 @@ if (functionType === "costView") {
 	var result = ac.costPermGeo(number);
 	console.log(result);
 }
+
+function usage () {
+	console.log(" ");
+	console.log("Usage");
+	console.log(" ");
+	console.log("To calculate map view cost: `ac costView x`, where x equals the number of estimated views");
+	console.log("To calculate permanent geocoding cost: `ac costPermGeo y`, where y equals the number of estimated permanent geocodes");  
+}
+
+if (help) {
+	usage();
+}
+


### PR DESCRIPTION
User can now run `ac --help`; returns:  

> Usage  
> To calculate map view cost: `ac costView x`, where x equals the number of estimated views
> To calculate permanent geocoding cost: `ac costPermGeo y`, where y equals the number of estimated permanent geocodes

fixes: https://github.com/alianthes/ali-cuts/issues/1
